### PR TITLE
Remove need for being aligned with ball to kick it

### DIFF
--- a/src/asl/robo.asl
+++ b/src/asl/robo.asl
@@ -56,7 +56,6 @@ beforeKickoff(true).
     :
               seeBall(M,D)
         & not seeGoal(true)
-        &     ballAligned(true)
         &     inKickRange(true)
 	<-
 	    .print("p5")
@@ -68,7 +67,6 @@ beforeKickoff(true).
     :
            seeBall(M,D)
         &  seeGoal(true)
-        &  ballAligned(true)
         &  inKickRange(true)
     <-
         .print("p6")


### PR DESCRIPTION
The ball doesn't need to be in front for the agent to be able to kick
it. This extra requirement could cause the agent to get stuck.