### PR TITLE
Agent perceives the game mode, updated plans

### DIFF
--- a/src/asl/robo.asl
+++ b/src/asl/robo.asl
@@ -5,19 +5,30 @@ inKickRange(D):- D <= 1.
 aligned(M):- M == 0.
 
 // The agent believes we are before the kickoff
-beforeKickoff(true).
+//beforeKickoff(true).
 
 /* Initial goals */
 !play.
 
 /* Plans */
+@p0
++!play
+    : 
+    	gameMode(before_kick_off)
+      & seeBall(Mb,Db)
+      & aligned(Mb)
+    <-
+        turn(0);
+        !play.
+
 @p1
 +!play
-    : beforeKickoff(true)
+    : 
+       not inField
     <-
         .print("Before Kickoff");
         move(math.random(54) - 54, math.random(64) - 32);
-        -beforeKickoff(true);
+        +inField;
         !play.
 
 @p2			  
@@ -53,6 +64,7 @@ beforeKickoff(true).
           seeBall(Mb,Db)
         & aligned(Mb)
         & not inKickRange(Db)
+        & not gameMode(before_kick_off)
     <-
         dash(10 * Db);
         !play.
@@ -73,6 +85,8 @@ beforeKickoff(true).
            seeBall(Mb,Db)
         &  inKickRange(Db)
         &  seeGoal(Mg,Dg)
+        &  not gameMode(before_kick_off)
     <-
         kick(100,Mg);
-        !play.
+        !play.   
+		

--- a/src/java/ca/carleton/sce/Brain.java
+++ b/src/java/ca/carleton/sce/Brain.java
@@ -57,6 +57,12 @@ class Brain implements SensorInput {
             sensorInfo.getGoalList().stream().filter(goal -> goal.getSide() != m_side).findAny().ifPresent(
                     goal -> percepts.add(ASSyntax.createLiteral("seeGoal", ASSyntax.createNumber(goal.getDirection()), ASSyntax.createNumber(goal.getDistance()))));
 
+            // Game mode percept
+            //if (!"before_kick_off".equals(m_playMode))
+            percepts.add(ASSyntax.createLiteral("gameMode", ASSyntax.createAtom(m_playMode)));
+            //if (m_timeOver)
+            //	percepts.add(ASSyntax.createLiteral("timeOver", ASSyntax.createAtom("true")));
+            
             sensorInfo.clear();
         });
 
@@ -92,6 +98,8 @@ class Brain implements SensorInput {
     public void hear(Message message) {
         if (message.getSender().equals(Sender.Referee) && "time_over".equals(message.getMessage())) {
             m_timeOver = true;
+        } else if (message.getSender().equals(Sender.Referee)) {
+            m_playMode = message.getMessage();
         } else {
             this.sensorInfo.lock(s -> s.hear(message));
         }


### PR DESCRIPTION
We can keep track of the play mode and perform plans only when it makes sense (i.e no dashing/kicking before kick off). plan p0 is kind of lame with turn(0)